### PR TITLE
removed duplicate info from the output of 'create-hibernate-cfg-xml' command

### DIFF
--- a/scripts/CreateHibernateCfgXml.groovy
+++ b/scripts/CreateHibernateCfgXml.groovy
@@ -30,7 +30,7 @@ target (createHibernateCfgXml: 'Creates a hibernate.cfg.xml file') {
     cfgFile = new File("$basedir/grails-app/conf/hibernate/hibernate.cfg.xml")
     ant.mkdir dir: cfgFile.parent
 
-    if (cfgFile.exists() && !confirmInput('hibernate.cfg.xml already exists. Overwrite? [y/n]', 'overwrite.hibernate_cfg_xml')) {
+    if (cfgFile.exists() && !confirmInput('hibernate.cfg.xml already exists. Overwrite?', 'overwrite.hibernate_cfg_xml')) {
         return
     }
 
@@ -51,7 +51,6 @@ target (createHibernateCfgXml: 'Creates a hibernate.cfg.xml file') {
     copyGrailsResource cfgFile.path, templateFile
 
     event 'CreatedFile', [cfgFile.path]
-    grailsConsole.updateStatus "Created $cfgFile.path"
 }
 
 setDefaultTarget 'createHibernateCfgXml'


### PR DESCRIPTION
bofore:

```
$ grails create-hibernate-cfg-xml
> hibernate.cfg.xml already exists. Overwrite? [y/n][y,n] y
| Created file grails-app/conf/hibernate/hibernate.cfg.xml
| Created /Users/yamkazu/Desktop/demo/grails-app/conf/hibernate/hibernate.cfg.xml
```

after:

```
$ grails create-hibernate-cfg-xml
> hibernate.cfg.xml already exists. Overwrite?[y,n] y
| Created file grails-app/conf/hibernate/hibernate.cfg.xml
```
