### PR TITLE
Drop the ehcache dependency. Caching is a separate concern.

### DIFF
--- a/grails-app/conf/BuildConfig.groovy
+++ b/grails-app/conf/BuildConfig.groovy
@@ -63,7 +63,6 @@ grails.project.dependency.resolution = {
         runtime "org.hibernate:hibernate-ehcache:$hibernateVersion", {
             exclude group: 'net.sf.ehcache', name: 'ehcache-core'
         }
-        runtime "net.sf.ehcache:ehcache-core:2.4.8"
     }
 
     plugins {

--- a/test/unit/org/codehaus/groovy/grails/orm/hibernate/AbstractGrailsHibernateTests.groovy
+++ b/test/unit/org/codehaus/groovy/grails/orm/hibernate/AbstractGrailsHibernateTests.groovy
@@ -147,9 +147,6 @@ dataSource {
     }
 }
 hibernate {
-    cache.use_second_level_cache=true
-    cache.use_query_cache=true
-    cache.provider_class='net.sf.ehcache.hibernate.EhCacheProvider'
 }
 ''', "DataSource")
     }
@@ -194,13 +191,6 @@ hibernate {
         }
         catch(e) {
             // means it is not active, ignore
-        }
-        try {
-            getClass().classLoader.loadClass("net.sf.ehcache.CacheManager")
-                                    .getInstance()?.shutdown()
-        }
-        catch(e) {
-            // means there is no cache, ignore
         }
         gcl = null
         ga = null

--- a/test/unit/org/codehaus/groovy/grails/orm/hibernate/GormSpec.groovy
+++ b/test/unit/org/codehaus/groovy/grails/orm/hibernate/GormSpec.groovy
@@ -92,13 +92,6 @@ abstract class GormSpec extends Specification {
         catch(e) {
             // means it is not active, ignore
         }
-        try {
-            getClass().classLoader.loadClass("net.sf.ehcache.CacheManager")
-                                    .getInstance()?.shutdown()
-        }
-        catch(e) {
-            // means there is no cache, ignore
-        }
         gcl = null
         grailsApplication = null
         mockManager = null
@@ -190,9 +183,6 @@ dataSource {
     url = "jdbc:h2:mem:grailsIntTestDB"
 }
 hibernate {
-    cache.use_second_level_cache=true
-    cache.use_query_cache=true
-    cache.provider_class='net.sf.ehcache.hibernate.EhCacheProvider'
 }
 ''', "DataSource")
     }

--- a/test/unit/org/codehaus/groovy/grails/orm/hibernate/MultipleDataSourceTests.groovy
+++ b/test/unit/org/codehaus/groovy/grails/orm/hibernate/MultipleDataSourceTests.groovy
@@ -209,9 +209,6 @@ dataSource_ds4 {
 }
 
 hibernate {
-    cache.use_second_level_cache = true
-    cache.use_query_cache = true
-    cache.provider_class='net.sf.ehcache.hibernate.EhCacheProvider'
 }
 ''', 'DataSource')
     }

--- a/test/unit/org/codehaus/groovy/grails/orm/hibernate/validation/HibernateMappingUniqueConstraintTests.groovy
+++ b/test/unit/org/codehaus/groovy/grails/orm/hibernate/validation/HibernateMappingUniqueConstraintTests.groovy
@@ -42,9 +42,6 @@ dataSource {
     }
 }
 hibernate {
-    cache.use_second_level_cache=true
-    cache.use_query_cache=true
-    cache.provider_class='net.sf.ehcache.hibernate.EhCacheProvider'
     config.location = ['classpath:/org/codehaus/groovy/grails/orm/hibernate/validation/hibernate.cfg.xml']
 }
 ''', "DataSource")


### PR DESCRIPTION
I don't think Hibernate and Hibernate4 should depend on ehcache at all.

It seems to me that caching is a separate concern that should be addressed by a separate plugin (namely, the cache-ehcache plugin).

Setting up Hibernate caching with ehcache properly isn't as simple as how it's currently done in the Hibernate/Hibernate4, too:
cache.provider_class='net.sf.ehcache.hibernate.EhCacheProvider'
That isn't right because with that setup, there's a separate ehcache instance set up just for Hibernate, and it is only configurable using the default class path ehcache.xml (which falls back to ehcache-failsafe.xml). It doesn't get shutdown safely either (whereas the cache-ehcache plugin does safely shut it down) which causes problems when running distributed, or with a disk backing store.

I think the correct way to configure Hibernate with ehcache is as documented in the cache-ehcache plugin at https://grails-plugins.github.io/grails-cache-ehcache/guide/usage.html :
   cache.region.factory_class = 'grails.plugin.cache.ehcache.hibernate.BeanEhcacheRegionFactory' // For Hibernate before 4.0
   cache.region.factory_class = 'grails.plugin.cache.ehcache.hibernate.BeanEhcacheRegionFactory4' // For Hibernate before 4.0 and higher

You can see BeanEhcacheRegionFactory at https://github.com/grails-plugins/grails-cache-ehcache/blob/master/src/java/grails/plugin/cache/ehcache/hibernate/BeanEhcacheRegionFactory.java

In short, I propose the ehcache dependency be dropped from both plugins, and people use cache-ehcache if they want to use ehcache.
