### PR TITLE
Update to GDC 3.1.5.RELEASE

### DIFF
--- a/grails-app/conf/BuildConfig.groovy
+++ b/grails-app/conf/BuildConfig.groovy
@@ -29,7 +29,7 @@ grails.project.dependency.resolution = {
     }
 
     dependencies {
-        String datastoreVersion = '3.1.4.RELEASE'
+        String datastoreVersion = '3.1.5.RELEASE'
         String hibernateVersion = '3.6.10.Final'
 
         compile "org.grails:grails-datastore-core:$datastoreVersion",


### PR DESCRIPTION
Unit tests pass fine

This fixes an issue where mappedBy='none' was breaking unit tests. We can specify this version of GDC in our project's build config as a workaround.
